### PR TITLE
Allow GO_Utils to be used in batch mode

### DIFF
--- a/GO_Utils/__init__.py
+++ b/GO_Utils/__init__.py
@@ -11,8 +11,7 @@ class GoSettings(object):
 
     def __init__(self):
         self.storage = {}
-        #TODO: maybe here() not best option
-        self.bt_obj = Utils.get_bitness(idc.here())
+        self.bt_obj = Utils.get_bitness(idc.BeginEA())
         self.structCreator = Utils.StructCreator(self.bt_obj)
         self.processor = None
         self.typer = None


### PR DESCRIPTION
The GO_Utils initialization relied on idc.here(), which when run in batch mode would result in the following error:

    Z:\vm\IDAGolangHelper-master\auto_go_rename.py: could not find segment at 0xffffffffffffffff
    Traceback (most recent call last):
      File "C:\Program Files\IDA 7.0\python\ida_idaapi.py", line 553, in IDAPython_ExecScript
        execfile(script, g)
      File "Z:/vm/IDAGolangHelper-master/auto_go_rename.py", line 29, in <module>
        GO_SETTINGS = GO_Utils.GoSettings()
      File "Z:/vm/IDAGolangHelper-master\GO_Utils\__init__.py", line 15, in __init__
        self.bt_obj = Utils.get_bitness(idc.here())
      File "Z:/vm/IDAGolangHelper-master\GO_Utils\Utils.py", line 35, in get_bitness
        if idc.GetSegmentAttr(addr, idc.SEGATTR_BITNESS) == 2:
      File "C:\Program Files\IDA 7.0\python\idc_bc695.py", line 152, in GetSegmentAttr
        def GetSegmentAttr(segea, attr): return get_segm_attr(segea, attr)
      File "C:\Program Files\IDA 7.0\python\idc.py", line 3508, in get_segm_attr
        assert seg, "could not find segment at 0x%x" % segea
    AssertionError: could not find segment at 0xffffffffffffffff

Even having the script Jump(BeginEA()) before initializing the library would trigger this error occasionally.  Replacing idc.here() with idc.BeginEA() resolved the issue.

As a side note, thanks for the great script!  It is a big help when reversing Go binaries!