### PR TITLE
Fix LineTable search

### DIFF
--- a/GO_Utils/Gopclntab.py
+++ b/GO_Utils/Gopclntab.py
@@ -27,13 +27,14 @@ def check_is_gopclntab(addr):
 
 
 def findGoPcLn():
-    end_ea = idc.get_segm_end(0)
-    possible_loc = ida_search.find_binary(0, end_ea, lookup, 16, idc.SEARCH_DOWN) #header of gopclntab
-
-    if check_is_gopclntab(possible_loc):
-        return possible_loc
-    else:
-        return None
+    possible_loc = ida_search.find_binary(0, idc.BADADDR, lookup, 16, idc.SEARCH_DOWN) #header of gopclntab
+    while possible_loc != idc.BADADDR:
+        if check_is_gopclntab(possible_loc):
+            return possible_loc
+        else:
+            #keep searching till we reach end of binary
+            possible_loc = ida_search.find_binary(possible_loc+1, idc.BADADDR, lookup, 16, idc.SEARCH_DOWN)
+    return None
 
 
 def rename(beg, ptr, make_funcs = True):

--- a/GO_Utils/Gopclntab.py
+++ b/GO_Utils/Gopclntab.py
@@ -29,10 +29,6 @@ def check_is_gopclntab(addr):
 def findGoPcLn():
     end_ea = idc.get_segm_end(0)
     possible_loc = ida_search.find_binary(0, end_ea, lookup, 16, idc.SEARCH_DOWN) #header of gopclntab
-    print("Possible gopclntab: %s" % hex(possible_loc))
-
-    # gopclntab = ida_segment.get_segm_by_name('.gopclntab')
-    # print("Possible gopclntab: %s" % hex(gopclntab))
 
     if check_is_gopclntab(possible_loc):
         return possible_loc

--- a/GO_Utils/Gopclntab.py
+++ b/GO_Utils/Gopclntab.py
@@ -4,6 +4,7 @@ import idaapi
 import ida_bytes
 import ida_funcs
 import ida_search
+import ida_segment
 import Utils
 
 info = idaapi.get_inf_structure()
@@ -26,16 +27,17 @@ def check_is_gopclntab(addr):
 
 
 def findGoPcLn():
-    pos = idautils.Functions().next() # Get some valid address in .text segment
-    while True:
-        end_ea = idc.get_segm_end(pos)
-        possible_loc = ida_search.find_binary(pos, end_ea, lookup, 16, idc.SEARCH_DOWN) #header of gopclntab
-        if possible_loc == idc.BADADDR:
-            break
-        if check_is_gopclntab(possible_loc):
-            return possible_loc
-        pos = possible_loc+1
-    return None
+    end_ea = idc.get_segm_end(0)
+    possible_loc = ida_search.find_binary(0, end_ea, lookup, 16, idc.SEARCH_DOWN) #header of gopclntab
+    print("Possible gopclntab: %s" % hex(possible_loc))
+
+    # gopclntab = ida_segment.get_segm_by_name('.gopclntab')
+    # print("Possible gopclntab: %s" % hex(gopclntab))
+
+    if check_is_gopclntab(possible_loc):
+        return possible_loc
+    else:
+        return None
 
 
 def rename(beg, ptr, make_funcs = True):

--- a/GO_Utils/__init__.py
+++ b/GO_Utils/__init__.py
@@ -55,26 +55,32 @@ class GoSettings(object):
         Gopclntab.rename(gopcln_tab, self.bt_obj)
 
     def getVersionByString(self):
-        pos = idautils.Functions().next()
-        end_ea = idc.get_segm_end(pos)
+        # pos = idautils.Functions().next()
+        end_ea = idc.get_segm_end(0)
         
-        if ida_search.find_binary(pos, end_ea, "67 6f 31 2e 31 30", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 31 33", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+            return 'Go 1.13'
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 31 32", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+            return 'Go 1.12'
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 31 31", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+            return 'Go 1.11'
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 31 30", 16, idc.SEARCH_DOWN) != idc.BADADDR:
             return 'Go 1.10'
-        if ida_search.find_binary(pos, end_ea, "67 6f 31 2e 39", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 39", 16, idc.SEARCH_DOWN) != idc.BADADDR:
             return 'Go 1.9'
-        if ida_search.find_binary(pos, end_ea, "67 6f 31 2e 38", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 38", 16, idc.SEARCH_DOWN) != idc.BADADDR:
             return 'Go 1.8'
-        if ida_search.find_binary(pos, end_ea, "67 6f 31 2e 37", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 37", 16, idc.SEARCH_DOWN) != idc.BADADDR:
             return 'Go 1.7'
-        if ida_search.find_binary(pos, end_ea, "67 6f 31 2e 36", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 36", 16, idc.SEARCH_DOWN) != idc.BADADDR:
             return 'Go 1.6'
-        if ida_search.find_binary(pos, end_ea, "67 6f 31 2e 35", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 35", 16, idc.SEARCH_DOWN) != idc.BADADDR:
             return 'Go 1.5'
-        if ida_search.find_binary(pos, end_ea, "67 6f 31 2e 34", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 34", 16, idc.SEARCH_DOWN) != idc.BADADDR:
             return 'Go 1.4'
-        if ida_search.find_binary(pos, end_ea, "67 6f 31 2e 33", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 33", 16, idc.SEARCH_DOWN) != idc.BADADDR:
             return 'Go 1.3'
-        if ida_search.find_binary(pos, end_ea, "67 6f 31 2e 32", 16, idc.SEARCH_DOWN) != idc.BADADDR:
+        if ida_search.find_binary(0, end_ea, "67 6f 31 2e 32", 16, idc.SEARCH_DOWN) != idc.BADADDR:
             return 'Go 1.2'
 
     def createTyper(self, typ):


### PR DESCRIPTION
Gopclntab.findGoPcLn() now performs a search across the entire binary instead of only searching IDA defined functions. This fixes #11 where in some cases the plugin was unable to find the LineTable.