### PR TITLE
fix #14

### DIFF
--- a/GO_Utils/__init__.py
+++ b/GO_Utils/__init__.py
@@ -13,7 +13,7 @@ class GoSettings(object):
 
     def __init__(self):
         self.storage = {}
-        self.bt_obj = Utils.get_bitness(ida_ida.inf_get_min_ea())
+        self.bt_obj = Utils.get_bitness(idc.BeginEA())
         self.structCreator = Utils.StructCreator(self.bt_obj)
         self.processor = None
         self.typer = None


### PR DESCRIPTION
According to https://www.hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml, `idc.BeginEA()` has replaced ` ida_ida.inf_get_min_ea() ` in version 7.4

However when trying to import this script in 7.2, we still get #14 

This patch should work at least on 7.2