### PR TITLE
Added import to go_entry.  Wasn't working without

### DIFF
--- a/go_entry.py
+++ b/go_entry.py
@@ -3,6 +3,7 @@
 # (c) Hex-Rays
 #
 import GO_Utils
+import idaapi
 idaapi.require("GO_Utils")
 idaapi.require("GO_Utils.Gopclntab")
 idaapi.require("GO_Utils.Utils")


### PR DESCRIPTION
`go_entry.py` requires `import idaapi` in order to execute properly

It was failing on IDA v7.4 